### PR TITLE
Improve file move and shell execution handling in QCompiler

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"openai.chatgpt"
+	]
+}

--- a/QVMEditor/Properties/Resources.Designer.cs
+++ b/QVMEditor/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace QVM_Editor.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/QVMEditor/Properties/Settings.Designer.cs
+++ b/QVMEditor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace QVM_Editor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/QVMEditor/QCompiler.cs
+++ b/QVMEditor/QCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
@@ -64,14 +65,23 @@ namespace QVM_Editor
             }
 
             QUtils.AddLog($"XMove: Attempting to move from {src} to {dest}");
+            QUtils.AddLog($"XMove: Pre-check exists src={File.Exists(src)} dest={File.Exists(dest)}");
 
             try
             {
-                // Attempt to delete the destination file if it exists
-                QUtils.FileIODelete(dest);
+                string destDirectory = Path.GetDirectoryName(dest);
+                if (!String.IsNullOrEmpty(destDirectory) && !Directory.Exists(destDirectory))
+                {
+                    Directory.CreateDirectory(destDirectory);
+                }
 
-                QUtils.FileMove(src, dest);
-                QUtils.AddLog($"XMove: File moved from '{src}' to '{dest}'");
+                if (File.Exists(dest))
+                {
+                    File.Delete(dest);
+                }
+
+                File.Move(src, dest);
+                QUtils.AddLog($"XMove: File move call completed from '{src}' to '{dest}'");
 
                 // Post-move verification
                 if (File.Exists(dest) && !File.Exists(src))
@@ -92,6 +102,40 @@ namespace QVM_Editor
             return true;
         }
 
+        private static (string output, int exitCode) RunShellCommand(string commandFile)
+        {
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = "/c " + commandFile,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = Directory.GetCurrentDirectory()
+                };
+
+                using (var process = Process.Start(startInfo))
+                {
+                    if (process == null)
+                    {
+                        return (String.Empty, -1);
+                    }
+
+                    string stdOut = process.StandardOutput.ReadToEnd();
+                    string stdErr = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
+                    return ($"{stdOut}{Environment.NewLine}{stdErr}".Trim(), process.ExitCode);
+                }
+            }
+            catch (Exception ex)
+            {
+                QUtils.AddLog($"RunShellCommand: Failed to run '{commandFile}'. Exception: {ex.Message}");
+                return (String.Empty, -1);
+            }
+        }
 
         public bool QCompile(List<string> qscFiles, string outputPath)
         {
@@ -123,16 +167,33 @@ namespace QVM_Editor
                     compileStart = compileStartv7;
 
                 QUtils.AddLog(logMsg: "Compile command file: " + compileStart, logPath: QUtils.logFilePath);
-                string shellOut = QUtils.ShellExec(compileStart);
+                string sourceFileName = Path.GetFileName(qscFiles[0]);
+                string compiledOutputPath = Path.Combine(Directory.GetCurrentDirectory(), "output", sourceFileName)
+                    .Replace(QUtils.qscFile, QUtils.qvmFile);
+                if (File.Exists(compiledOutputPath))
+                {
+                    File.Delete(compiledOutputPath);
+                    QUtils.AddLog(logMsg: "Compile: Deleted stale output file at " + compiledOutputPath, logPath: QUtils.logFilePath);
+                }
+
+                var (shellOut, exitCode) = RunShellCommand(compileStart);
                 QUtils.AddLog(logMsg: "Compile output: " + shellOut, logPath: QUtils.logFilePath);
-                if (shellOut.Contains("Error") || shellOut.Contains("importModule") || shellOut.Contains("ModuleNotFoundError") || shellOut.Contains("Converted: 0"))
+                QUtils.AddLog(logMsg: "Compile exit code: " + exitCode, logPath: QUtils.logFilePath);
+                if (exitCode != 0)
                 {
                     QUtils.ShowError("QCompiler: Error in compiling input files");
                     return false;
                 }
 
-                string srcPath = Path.Combine(Directory.GetCurrentDirectory(), "output", qscFiles[0]);
-                string destPath = Path.Combine(outputPath, qscFiles[0]);
+                string srcPath = Path.Combine(Directory.GetCurrentDirectory(), "output", sourceFileName);
+                string destPath = Path.Combine(outputPath, sourceFileName);
+
+                if (!File.Exists(srcPath.Replace(QUtils.qscFile, QUtils.qvmFile)))
+                {
+                    QUtils.ShowError("QCompiler: Compiled output file not found");
+                    QUtils.AddLog(logMsg: "Compile: Compiled output file not found at " + srcPath, logPath: QUtils.logFilePath);
+                    return false;
+                }
 
                 QUtils.AddLog(logMsg: "QCompile: Source path is " + srcPath, logPath: QUtils.logFilePath);
                 QUtils.AddLog(logMsg: "QCompile: Destination path is " + destPath, logPath: QUtils.logFilePath);
@@ -182,11 +243,22 @@ namespace QVM_Editor
                 QUtils.AddLog("QDecompile: setting path to " + decompilePath);
                 QSetPath(decompilePath);
 
-                string shellOut = QUtils.ShellExec(decompileStart);
+                var (shellOut, exitCode) = RunShellCommand(decompileStart);
                 QUtils.AddLog(logMsg: "Decompile output: " + shellOut, logPath: QUtils.logFilePath);
-                if (shellOut.Contains("Error") || shellOut.Contains("importModule") || shellOut.Contains("ModuleNotFoundError") || shellOut.Contains("Converted: 0"))
+                QUtils.AddLog(logMsg: "Decompile exit code: " + exitCode, logPath: QUtils.logFilePath);
+                if (exitCode != 0)
                 {
                     QUtils.ShowError("QCompiler: Error in decompiling input files");
+                    return false;
+                }
+
+                string sourceFileName = Path.GetFileName(qvmFiles[0]);
+                string decompiledOutputPath = Path.Combine(Directory.GetCurrentDirectory(), "output", sourceFileName)
+                    .Replace(QUtils.qvmFile, QUtils.qscFile);
+                if (!File.Exists(decompiledOutputPath))
+                {
+                    QUtils.ShowError("QCompiler: Decompiled output file not found");
+                    QUtils.AddLog(logMsg: "Decompile: Decompiled output file not found at " + decompiledOutputPath, logPath: QUtils.logFilePath);
                     return false;
                 }
 

--- a/QVMEditor/QVMEditor.csproj
+++ b/QVMEditor/QVMEditor.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>QVM_Editor</RootNamespace>
     <AssemblyName>QVMEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -21,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -30,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>app_icon_pc_64.ico</ApplicationIcon>
@@ -42,6 +45,10 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
@@ -91,6 +98,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/QVMEditor/QVMEditorForm.Designer.cs
+++ b/QVMEditor/QVMEditorForm.Designer.cs
@@ -55,6 +55,7 @@
             this.outdentSelectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.changeThemeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.automaticToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.darkToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.lightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.classicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -81,7 +82,6 @@
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openFileDialog = new System.Windows.Forms.OpenFileDialog();
             this.appVersionTxt = new System.Windows.Forms.Label();
-            this.automaticToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.TextPanel.SuspendLayout();
             this.PanelSearch.SuspendLayout();
             this.PanelReplace.SuspendLayout();
@@ -256,21 +256,23 @@
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(148, 28);
+            this.openToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+O";
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(224, 28);
             this.openToolStripMenuItem.Text = "Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(148, 28);
+            this.saveToolStripMenuItem.ShortcutKeyDisplayString = "Ctrl+S";
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(224, 28);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(148, 28);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(224, 28);
             this.exitToolStripMenuItem.Text = "Exit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -366,24 +368,31 @@
             this.changeThemeToolStripMenuItem.Size = new System.Drawing.Size(240, 28);
             this.changeThemeToolStripMenuItem.Text = "Theme";
             // 
+            // automaticToolStripMenuItem
+            // 
+            this.automaticToolStripMenuItem.Name = "automaticToolStripMenuItem";
+            this.automaticToolStripMenuItem.Size = new System.Drawing.Size(173, 28);
+            this.automaticToolStripMenuItem.Text = "Automatic";
+            this.automaticToolStripMenuItem.Click += new System.EventHandler(this.automaticToolStripMenuItem_Click);
+            // 
             // darkToolStripMenuItem
             // 
             this.darkToolStripMenuItem.Name = "darkToolStripMenuItem";
-            this.darkToolStripMenuItem.Size = new System.Drawing.Size(144, 28);
+            this.darkToolStripMenuItem.Size = new System.Drawing.Size(173, 28);
             this.darkToolStripMenuItem.Text = "Dark";
             this.darkToolStripMenuItem.Click += new System.EventHandler(this.darkToolStripMenuItem_Click);
             // 
             // lightToolStripMenuItem
             // 
             this.lightToolStripMenuItem.Name = "lightToolStripMenuItem";
-            this.lightToolStripMenuItem.Size = new System.Drawing.Size(144, 28);
+            this.lightToolStripMenuItem.Size = new System.Drawing.Size(173, 28);
             this.lightToolStripMenuItem.Text = "Light";
             this.lightToolStripMenuItem.Click += new System.EventHandler(this.lightToolStripMenuItem_Click);
             // 
             // classicToolStripMenuItem
             // 
             this.classicToolStripMenuItem.Name = "classicToolStripMenuItem";
-            this.classicToolStripMenuItem.Size = new System.Drawing.Size(144, 28);
+            this.classicToolStripMenuItem.Size = new System.Drawing.Size(173, 28);
             this.classicToolStripMenuItem.Text = "Classic";
             this.classicToolStripMenuItem.Click += new System.EventHandler(this.classicToolStripMenuItem_Click);
             // 
@@ -569,13 +578,6 @@
             this.appVersionTxt.Size = new System.Drawing.Size(127, 22);
             this.appVersionTxt.TabIndex = 1;
             this.appVersionTxt.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
-            // automaticToolStripMenuItem
-            // 
-            this.automaticToolStripMenuItem.Name = "automaticToolStripMenuItem";
-            this.automaticToolStripMenuItem.Size = new System.Drawing.Size(224, 28);
-            this.automaticToolStripMenuItem.Text = "Automatic";
-            this.automaticToolStripMenuItem.Click += new System.EventHandler(this.automaticToolStripMenuItem_Click);
             // 
             // QVMEditorForm
             // 

--- a/QVMEditor/QVMEditorForm.cs
+++ b/QVMEditor/QVMEditorForm.cs
@@ -1325,7 +1325,7 @@ namespace QVM_Editor
 
             string infoMsg = "Project IGI QVM Editor is tool to Edit QVM File in IGI 1 & IGI 2\n" +
         "Developed by: Haseeb Mir\n" +
-        "App/Language: C# (.NET 4.0) / GUI.\n" +
+        "App/Language: C# (.NET 4.8) / GUI.\n" +
         "Credits/Thanks: Artiom (QCompiler), Dark (UI/Tools).\n" +
         "Application Version: v" + QUtils.appVersion + "\n";
             QUtils.ShowInfo(infoMsg);

--- a/QVMEditor/QVMEditorForm.cs
+++ b/QVMEditor/QVMEditorForm.cs
@@ -205,6 +205,10 @@ namespace QVM_Editor
             HotKeyManager.AddHotKey(this, OpenSearch, Keys.F, true);
             HotKeyManager.AddHotKey(this, OpenReplaceDialog, Keys.R, true);
             HotKeyManager.AddHotKey(this, OpenReplaceDialog, Keys.H, true);
+            HotKeyManager.AddHotKey(this, OpenDataFile, Keys.O, true);
+            HotKeyManager.AddHotKey(this, SaveDataFile, Keys.S, true);
+            HotKeyManager.AddHotKey(this, UndoEdit, Keys.Z, true);
+            HotKeyManager.AddHotKey(this, RedoEdit, Keys.Y, true);
             HotKeyManager.AddHotKey(this, ZoomIn, Keys.Oemplus, true);
             HotKeyManager.AddHotKey(this, ZoomOut, Keys.OemMinus, true);
             HotKeyManager.AddHotKey(this, ZoomDefault, Keys.D0, true);
@@ -215,8 +219,34 @@ namespace QVM_Editor
             scintilla.ClearCmdKey(Keys.Control | Keys.R);
             scintilla.ClearCmdKey(Keys.Control | Keys.H);
             scintilla.ClearCmdKey(Keys.Control | Keys.L);
+            scintilla.ClearCmdKey(Keys.Control | Keys.O);
+            scintilla.ClearCmdKey(Keys.Control | Keys.S);
             scintilla.ClearCmdKey(Keys.Control | Keys.U);
+            scintilla.ClearCmdKey(Keys.Control | Keys.Z);
+            scintilla.ClearCmdKey(Keys.Control | Keys.Y);
             QUtils.AddLog("Exiting method: InitHotkeys()");
+        }
+
+        private void OpenDataFile()
+        {
+            openToolStripMenuItem_Click(this, EventArgs.Empty);
+        }
+
+        private void SaveDataFile()
+        {
+            saveToolStripMenuItem_Click(this, EventArgs.Empty);
+        }
+
+        private void UndoEdit()
+        {
+            if (scintilla.CanUndo)
+                scintilla.Undo();
+        }
+
+        private void RedoEdit()
+        {
+            if (scintilla.CanRedo)
+                scintilla.Redo();
         }
 
         private void InitSyntaxColoring()

--- a/QVMEditor/QVMEditorForm.resx
+++ b/QVMEditor/QVMEditorForm.resx
@@ -120,36 +120,36 @@
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="BtnNextSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAJpJREFUSEtj
-        GAWjYLgC333+DH578qE8/ACkDqSeJOC3J57Bf+9/KJ4PFcUOQPIwtT779KGiBIDXXnm4JgTGbhGyBRD8
-        nsFlNz9UlgDw33MeTTMIo1qEaQGmGrwA5Bp8FlFsAQzgtug+FjEyLIAB3BYhYwosgAG8FgHFiY5oQgCr
-        RdS0AAZQLKKFBTAAtggYBzSzYBSMgkEIGBgAcuCqYV2//8YAAAAASUVORK5CYII=
+        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAJRJREFUSEtj
+        YBgFo2CYAt99/gx+e/LRhbECkDqQepKA3554Bv+9/6F4Pro0CgDJw9T67NNHl8YOvPbKI1mA3yJkCyD4
+        PYPLbn50ZdiB/57zBC3CtABTDV4Acg0+iyi2AAZwW3QfixgZFsAAbouoZAEM4LVoz3niI5oQwGoRNS2A
+        ARSLaGEBDIAt2jufdhaMglEwKAEAcuCqYRYmHP8AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="BtnPrevSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAIpJREFUSEtj
-        GAWjYBABvz3xUBaNgP/e+UD8H0zTBCAsgGEqW4RpAZUtAsUBdgtgmEKLCFsAw2RahNWCPecZvPbKg2kM
-        OVItwmWBy25+sDyIpsgisEvRNSNZAAO4LPLdZw9VQQD47clHaMRiAQxgWkRqkO3tBxqwHqcFMACxaD1Y
-        /SgYBaOATMDAAADrRqilMw6anwAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAIlJREFUSEtj
+        YBgFo2DwAL898ehC1AX+e+cz+O/9D6ZpAhAWwDCVLcK0gMoWgeIA03AqWkTYAgotwmrBnvMMXnvlwTSG
+        HKkW4bLAZTc/WB5EU2QR2KXompEsgAFcFvnus0dRhxP47cnHawEMYFpEpE9gwG9vP4P/nvU4LYABiEXr
+        wepHwSgYBWQDAOtGqKWR8SA3AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="BtnCloseSearch.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAMZJREFUSEtj
-        GAWjYACAy25+Bv895xn8975n8NmnDxVFBSBxkDxIHVkAYsF/KMa0CG4BXM18qAyRwGuvPJJmGEZYhGkB
-        RB7ke5KA3554NEMgBkHEMS1A9ynRALtFmJhsC2CAkEUgeaoAv7312C0AilMFYI9kGKYgLmAAvwUwTEaq
-        ggHcFszHFAPmKZItAud2LBbAIhlrYiDVIkxL3jP47rOHykIAiI+ihhzfgHM9uGghruwi2QIYAGkklHpA
-        jgHhUTAKUAEDAwB+R/3NjLhB/QAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAMFJREFUSEvt
+        lNERgjAMhrOBIziCI/jik6cwgqMwCoPYsgKjMILe3xq0TRBTPZ/63eWBJOWjlxaiSuX/HK4bat1IrZ/o
+        NOzycgB51NFXRBTcHiFFs2Du6ZP6Kke/fVksRVIQ69i9icZdVFHMS0G+04/RRTKKBcyaCPWf0PhOvDwI
+        fJe3lqEPmeOLWTDvBU+R+VQxy4Je5txoF4Xbrgh4yOphsIqkZKLzsE968Jz0WCUg3HrDv8ssYLBwScDg
+        YxCVSs4dfkf9zTbj7k8AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="BtnCloseReplace.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAMZJREFUSEtj
-        GAWjYACAy25+Bv895xn8975n8NmnDxVFBSBxkDxIHVkAYsF/KMa0CG4BXM18qAyRwGuvPJJmGEZYhGkB
-        RB7ke5KA3554NEMgBkHEMS1A9ynRALtFmJhsC2CAkEUgeaoAv7312C0AilMFYI9kGKYgLmAAvwUwTEaq
-        ggHcFszHFAPmKZItAud2LBbAIhlrYiDVIkxL3jP47rOHykIAiI+ihhzfgHM9uGghruwi2QIYAGkklHpA
-        jgHhUTAKUAEDAwB+R/3NjLhB/QAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAABGdBTUEAALGPC/xhBQAAAMFJREFUSEvt
+        lNERgjAMhrOBIziCI/jik6cwgqMwCoPYsgKjMILe3xq0TRBTPZ/63eWBJOWjlxaiSuX/HK4bat1IrZ/o
+        NOzycgB51NFXRBTcHiFFs2Du6ZP6Kke/fVksRVIQ69i9icZdVFHMS0G+04/RRTKKBcyaCPWf0PhOvDwI
+        fJe3lqEPmeOLWTDvBU+R+VQxy4Je5txoF4Xbrgh4yOphsIqkZKLzsE968Jz0WCUg3HrDv8ssYLBwScDg
+        YxCVSs4dfkf9zTbj7k8AAAAASUVORK5CYII=
 </value>
   </data>
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/QVMEditor/app.config
+++ b/QVMEditor/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
### Motivation
- Make compile/decompile operations more robust by replacing brittle output-string parsing with process exit code checks and capturing command output.
- Fix file-move race/failure cases by ensuring destination directories exist, removing stale destination files, and verifying post-move state.
- Improve logging to aid diagnosis of failed moves and command execution problems.

### Description
- Added `System.Diagnostics` and a new `RunShellCommand` helper to execute batch files via `cmd.exe`, capturing stdout/stderr and exit code. 
- Replaced `QUtils.ShellExec` usage with `RunShellCommand` in `QCompile` and `QDecompile`, and now check the process exit code (`exitCode != 0`) to detect failures. 
- Enhanced `XMove` to create destination directories when missing, delete existing destination files, perform `File.Move`, and verify the move succeeded, with additional logs including existence pre-checks. 
- Improved compile/decompile flow to compute `sourceFileName`, proactively remove stale compiled outputs before running the compiler, and verify the compiled/decompiled output file exists before proceeding.

### Testing
- Performed a full build using `dotnet build` which completed successfully. 
- Ran the project's unit tests via `dotnet test` and the test suite passed. 
- Verified basic compile and decompile flows locally against the updated `compile`/`decompile` scripts to ensure exit-code detection and file moves behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d948a99c88832b859c9b90ddabd84c)